### PR TITLE
Add btest to check for performance regression

### DIFF
--- a/tests/analyzer/performance.zeek
+++ b/tests/analyzer/performance.zeek
@@ -1,0 +1,6 @@
+# @TEST-DOC: Check for performance regression
+#
+# @TEST-EXEC: btest-bg-run test $ZEEK -Cr ${TRACES}/stun-many.pcap %INPUT
+# @TEST-EXEC: btest-bg-wait 60
+
+@load analyzer


### PR DESCRIPTION
The new btest will fail if processing the `stun-many.pcap` takes more than 60 seconds. Testing with Zeek 5.2 and 6.2, the test failed with 5.2 for me. Interestingly, it failed with a segfault.